### PR TITLE
add support for feed-service v1.13.3

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.3.0-beta
 
 # The version number of the Feed Service.
-appVersion: "v1.11.0"
+appVersion: "v1.13.3"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Status: `beta`
 
 This chart bootstraps a **Feed Service deployment** to a Kubernetes Cluster using the Helm package manager. The specific configuration values will be added to a config map and will be injected as environment variables into the pod, which executes the Feed Service. The sensitive values are injected via Kubernetes secrets.
 
-**Remark:** This Helm chart version supports version `1.11.0` of the Feed Service.
+**Remark:** This Helm chart version supports version `1.13.3` of the Feed Service.
 
 Additional configuration options can be configured via environment variables, which can be added as required in section `extendedConfig` in the `values.yaml` file.
 

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -36,6 +36,9 @@ data:
   {{- if (.Values.globalConfig.logColors) }}
   PIRAL_LOG_COLORS: "{{ .Values.globalConfig.logColors }}"
   {{- end }}
+  {{- if (.Values.globalConfig.logFormat) }}
+  PIRAL_LOG_FORMAT: "{{ .Values.globalConfig.logFormat }}"
+  {{- end }}
   {{- if (.Values.globalConfig.auditHandler) }}
   PIRAL_AUDIT_HANDLER: "{{ .Values.globalConfig.auditHandler }}"
   {{- end }}
@@ -304,6 +307,33 @@ data:
   {{- end }}
   {{- if (.Values.cache.redis.prefix ) }}
   PIRAL_CACHE_REDIS_PREFIX: "{{ .Values.cache.redis.prefix }}"
+  {{- end }}
+  {{- end }}
+
+  ## -----------------------
+  ## Notification configuration
+  ## -----------------------
+  {{- if (.Values.notifications.provider) }}
+  PIRAL_NOTIFICATION: "{{ .Values.notifications.provider }}"
+  {{- end }}
+  ## SMTP
+  {{- if (eq .Values.notifications.provider "smtp") }}
+  PIRAL_NOTIFICATION_SMTP_HOST: "{{ required "Please provide the host name of the SMTP service" .Values.notifications.smtp.host }}"
+  PIRAL_NOTIFICATION_SMTP_AUTH_USER: "{{ required "Please provide the name of the SMTP service user" .Values.notifications.smtp.user }}"
+  {{- if (.Values.notifications.smtp.port )}}
+  PIRAL_NOTIFICATION_SMTP_PORT: "{{ .Values.notifications.smtp.port }}"
+  {{- end }}
+  {{- if (.Values.notifications.smtp.secure) }}
+  PIRAL_NOTIFICATION_SMTP_SECURE: "{{ .Values.notifications.smtp.secure }}"
+  {{- end }}
+  {{- if (.Values.notifications.smtp.sender) }}
+  PIRAL_NOTIFICATION_SMTP_SENDER: "{{ .Values.notifications.smtp.sender }}"
+  {{- end }}
+  {{- end }}
+  ## SendGrid
+  {{- if (eq .Values.notifications.provider "sendgrid") }}
+  {{- if (.Values.notifications.sendgrid.sender) }}
+  PIRAL_NOTIFICATION_SENDGRID_SENDER: "{{ .Values.notifications.sendgrid.sender }}"
   {{- end }}
   {{- end }}
 

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -82,3 +82,17 @@ data:
   {{- if (eq .Values.cache.provider "redis") }}
   PIRAL_CACHE_REDIS_AUTH_PASS: {{ required "Please provide the password for accessing the Redis cache" .Values.cache.redis.password | b64enc | quote }}
   {{- end }}
+
+  ## -----------------------
+  ## Notifications
+  ## -----------------------
+  ## SMTP
+  {{- if (eq .Values.notifications.provider "smtp") }}
+  {{- if (.Values.notifications.smtp.password) }}
+  PIRAL_NOTIFICATION_SMTP_AUTH_PASS: {{ .Values.notifications.smtp.password | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+  ## SendGrid
+  {{- if (eq .Values.notifications.provider "sendgrid") }}
+  PIRAL_NOTIFICATION_SENDGRID_KEY: {{ required "Please provide an API key for using SendGrid" .Values.notifications.sendgrid.apiKey | b64enc | quote }}
+  {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: piral.azurecr.io/piral-feed-service
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v1.11.0"
+  tag: "v1.13.3"
 
 # Configure the secret, which contains the credentials for the container registry.
 # For creating the image pull secret please visit:
@@ -113,6 +113,9 @@ globalConfig:
 
   # Sets if colors should be used (optional, default: "on") 
   logColors: "off"
+
+  # Sets the logging format; choice logstash, json, plain (default: logstash)
+  logFormat: "logstash"
 
   # The audit handler to use (optional, default: "none"); choices: "none", "local"
   auditHandler: "none"
@@ -413,6 +416,36 @@ cache:
     useTls: "no"
     # Prefix for the feed service keys in Redis
     prefix: "piral"
+
+
+
+# Configuration for notifications
+notifications:
+  # The notification provider to be used (default: none)
+  provider: ""
+  
+  # Configuration for the SMTP provider
+  smtp:
+    # Host name of the SMTP service (example: smtp.host.com)
+    host: ""
+    # Port of the SMTP service (default: 25)
+    port: "25"
+    # Determines if TLS/STARTTLS should be used; choices on, off (default: off)
+    secure: "off"
+    # Sets the name of the SMTP service user (example: user@host.com)
+    user: ""
+    # Sets the password of the SMTP service user (default: nothing)
+    password: ""
+    # Email address for the notifications (default: noreply@piral.cloud)
+    sender: "noreply@piral.cloud"
+
+  # Configuration for the SendGrid provider
+  sendgrid:
+    # API key for using SendGrid (example: SG.ABc_00-1234.ABcd1234)
+    apiKey: ""
+    # Email address for the notifications (default: noreply@piral.cloud)
+    sender: "noreply@piral.cloud"
+
 
 # Example configuration for storing data e.g. in a persistent file share as location,
 # when choosing the 'disk' provider for the file storage and/or database 


### PR DESCRIPTION
This PR adds support for version v.1.13.3 of the feed-service to the Helm chart.
- Added support for setting the logging format via `PIRAL_LOG_FORMAT` introduced in v1.11.1
- Added support for configuring notifications via SMTP or SendGrid introduced in v1.13.0
- Updated the README to display the currently supported version of the feed-service