### PR TITLE
Fix disk location paths; Update version numbers

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for operating the Piral Feed Service in Kubernetes
 type: application
 
 # The chart version.
-version: 0.3.0-beta
+version: 0.4.0-beta
 
 # The version number of the Feed Service.
-appVersion: "v1.13.3"
+appVersion: "v1.13.4"

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Piral Feed Service Helm Chart
 
-Chart version: `0.3.0`
+Chart version: `0.4.0`
 Status: `beta`
 
 ## Introduction
 
 This chart bootstraps a **Feed Service deployment** to a Kubernetes Cluster using the Helm package manager. The specific configuration values will be added to a config map and will be injected as environment variables into the pod, which executes the Feed Service. The sensitive values are injected via Kubernetes secrets.
 
-**Remark:** This Helm chart version supports version `1.13.3` of the Feed Service.
+**Remark:** This Helm chart version supports version `1.13.4` of the Feed Service.
 
 Additional configuration options can be configured via environment variables, which can be added as required in section `extendedConfig` in the `values.yaml` file.
 

--- a/values.yaml
+++ b/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: piral.azurecr.io/piral-feed-service
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v1.13.3"
+  tag: "v1.13.4"
 
 # Configure the secret, which contains the credentials for the container registry.
 # For creating the image pull secret please visit:
@@ -297,7 +297,7 @@ fileStorage:
 
   # Configuration for the local disk as file storage provider
   disk:
-    location: "./data/fs"
+    location: "/app/data"
 
   # Configuration for AWS S3
   awsS3:
@@ -355,7 +355,7 @@ database:
   # Configuration for the local disk as database provider
   disk:
     # Required. Local (Disk) storage location for the DB
-    location: "./data/db"
+    location: "/app/data"
     # Defines the interval to sync back from the disk in seconds (default: 0)
     syncRate: "0"
     # Prefix to be used for the file names of the tables (default: empty)


### PR DESCRIPTION
- This PR fixes an issue with the location paths of the file storage and database providers when set to "disk". The previously set paths pointed to a non-existing directory
- Updates version of feed-service to v1.13.4
- Increment version number
- Update README